### PR TITLE
polytomy filtering for triplets not trees

### DIFF
--- a/QuIBL.py
+++ b/QuIBL.py
@@ -78,16 +78,14 @@ def getTripBranches(treeList,canonOut):
 	output=[[None,[],[],[]] for i in range(lenIt)]
 	for counter,tree in enumerate(treeList):
 		tree.set_outgroup(canonOut)
-		#print tree.expand_polytomies()
-		if len(tree.expand_polytomies())>1:
-			print('Tree '+str(counter)+' skipped due to polytomy.')
-			continue
 		dist=0
 		#tree.set_outgroup(canonOut)
 		for index,triplet in enumerate(triples):
 			output[index][0]=triplet
 			tempTree=tree.copy('newick')
 			tempTree.prune(triplet,preserve_branch_length=True)
+			if len(tempTree.expand_polytomies())>1:
+				continue
 			common=tempTree.get_leaves()[0].get_common_ancestor(tempTree.get_leaves())
 			for x in common.get_children():
 				if not (x.is_leaf()):


### PR DESCRIPTION
When running QuIBL on an empirical dataset with trees for short regions (~500 bp; 20 species) I noticed that most trees were ignored because they contained polytomies. I thought that it is unnecessary to discard the whole tree in that case, because most of the triplets in the tree are not affected by the polytomy and could be used. I changed the code so that trees with polytomies are now used, but each of the triplets in the tree is tested for whether it contains a polytomy, and the triplet is ignored if it does. Does this make sense? I'm not sure whether my changes interfere with other parts of the code. I would be thankful if you could comment. If there's a good reason to ignore all trees with polytomies, please just let me know and reject my pull request.